### PR TITLE
feat: 인증 방식 변경, 인증 코드 생성 방식 변경

### DIFF
--- a/api-test/invite-test.http
+++ b/api-test/invite-test.http
@@ -1,6 +1,6 @@
 //로컬테스트는 localhost 입력
-@host = 15.164.59.0
-@plan-id = 1
+@host = localhost
+@plan-id = 10
 
 ### 로그인
 POST http://{{host}}:8080/v1/users/login
@@ -25,12 +25,12 @@ Content-Type: application/json
 Authorization: {{Authorization}}
 
 {
-  "email": ""
+  "email": "chmh3370@gmail.com"
 }
 
 
 ### 인증 코드 확인, 공동 작업자 추가
-POST http://{{host}}:8080/v1/plans/{{plan-id}}?authCode=
+GET http://{{host}}:8080/v1/plans/{{plan-id}}/invite?authCode=
 Content-Type: application/json
 Authorization: {{Authorization}}
 

--- a/api-test/invite-test.http
+++ b/api-test/invite-test.http
@@ -1,5 +1,6 @@
 //로컬테스트는 localhost 입력
 @host = 15.164.59.0
+@plan-id = 1
 
 ### 로그인
 POST http://{{host}}:8080/v1/users/login
@@ -19,7 +20,7 @@ Content-Type: application/json
 %}
 
 ### 인증 코드 전송
-POST http://{{host}}:8080/v1/plans/1/invite
+POST http://{{host}}:8080/v1/plans/{{plan-id}}/invite
 Content-Type: application/json
 Authorization: {{Authorization}}
 
@@ -29,7 +30,7 @@ Authorization: {{Authorization}}
 
 
 ### 인증 코드 확인, 공동 작업자 추가
-POST http://{{host}}:8080/v1/plans/1?authCode=
+POST http://{{host}}:8080/v1/plans/{{plan-id}}?authCode=
 Content-Type: application/json
 Authorization: {{Authorization}}
 

--- a/api-test/invite-test.http
+++ b/api-test/invite-test.http
@@ -29,11 +29,8 @@ Authorization: {{Authorization}}
 
 
 ### 인증 코드 확인, 공동 작업자 추가
-POST http://{{host}}:8080/v1/plans/1/authCode
+POST http://{{host}}:8080/v1/plans/1?authCode=
 Content-Type: application/json
 Authorization: {{Authorization}}
 
-{
-  "authCode": ""
-}
 

--- a/src/main/java/com/sparta/restplaceforj/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/restplaceforj/config/SecurityConfig.java
@@ -79,7 +79,6 @@ public class SecurityConfig {
             .permitAll() // resources 접근 허용 설정
             .requestMatchers("/v1/users").permitAll()
             .requestMatchers("/v1/users/login").permitAll()
-            .requestMatchers("/v1/posts/**").permitAll()
             .requestMatchers("/swagger-ui/**", "/swagger-ui.html",
                 "/v3/api-docs/**", "/swagger/", "/swagger-resources/")
             .permitAll()

--- a/src/main/java/com/sparta/restplaceforj/controller/InviteController.java
+++ b/src/main/java/com/sparta/restplaceforj/controller/InviteController.java
@@ -39,8 +39,7 @@ public class InviteController {
             @PathVariable("plan-id") Long planId,
             @AuthenticationPrincipal UserDetailsImpl userDetails) throws MessagingException {
 
-        inviteService.checkEmailInvalidation(emailRequestDto.getEmail(), userDetails.getUser(), planId);
-        inviteService.sendEmail(emailRequestDto.getEmail());
+        inviteService.sendEmail(emailRequestDto.getEmail(), planId, userDetails.getUser());
 
         return ResponseEntity.ok(
                 CommonResponse.builder()
@@ -53,19 +52,16 @@ public class InviteController {
     /**
      * 인증번호 유효성 검사, 공동작업자로 추가 controller
      *
-     * @param authCheckRequestDto : authCode
      * @param planId
-     * @param userDetails
+     * @param authCode
      * @return coworkerId
      */
-    @PostMapping("/authCode")
+    @PostMapping
     public ResponseEntity<CommonResponse<AuthCheckResponseDto>> AuthCheckAndCreateCoworker(
-            @RequestBody AuthCheckRequestDto authCheckRequestDto,
             @PathVariable("plan-id") Long planId,
-            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+            @RequestParam("authCode") String authCode) {
 
-        String email = inviteService.verifyAuthCode(authCheckRequestDto.getAuthCode());
-        AuthCheckResponseDto authCheckResponseDto = inviteService.createCoworker(planId, email);
+        AuthCheckResponseDto authCheckResponseDto = inviteService.createCoworker(planId, authCode);
 
 
         return ResponseEntity.ok(

--- a/src/main/java/com/sparta/restplaceforj/controller/InviteController.java
+++ b/src/main/java/com/sparta/restplaceforj/controller/InviteController.java
@@ -3,8 +3,6 @@ package com.sparta.restplaceforj.controller;
 
 import com.sparta.restplaceforj.common.CommonResponse;
 import com.sparta.restplaceforj.common.ResponseEnum;
-import com.sparta.restplaceforj.dto.AuthCheckRequestDto;
-import com.sparta.restplaceforj.dto.AuthCheckResponseDto;
 import com.sparta.restplaceforj.dto.EmailRequestDto;
 import com.sparta.restplaceforj.security.UserDetailsImpl;
 import com.sparta.restplaceforj.service.InviteService;

--- a/src/main/java/com/sparta/restplaceforj/controller/InviteController.java
+++ b/src/main/java/com/sparta/restplaceforj/controller/InviteController.java
@@ -13,13 +13,14 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 
 
-@RestController
+@Controller
 @RequiredArgsConstructor
-@RequestMapping("/v1/plans/{plan-id}")
+@RequestMapping("/v1/plans/{plan-id}/invite")
 public class InviteController {
 
     private final InviteService inviteService;
@@ -33,7 +34,8 @@ public class InviteController {
      * @param userDetails
      * @return null
      */
-    @PostMapping("/invite")
+    @ResponseBody
+    @PostMapping
     public ResponseEntity<CommonResponse> checkEmailAndSendAuthCode(
             @RequestBody @Valid EmailRequestDto emailRequestDto,
             @PathVariable("plan-id") Long planId,
@@ -56,25 +58,14 @@ public class InviteController {
      * @param authCode
      * @return coworkerId
      */
-    @PostMapping
-    public ResponseEntity<CommonResponse<AuthCheckResponseDto>> AuthCheckAndCreateCoworker(
+    @GetMapping
+    public String AuthCheckAndCreateCoworker(
             @PathVariable("plan-id") Long planId,
-            @RequestParam("authCode") String authCode) {
+            @RequestParam String authCode) {
 
-        AuthCheckResponseDto authCheckResponseDto = inviteService.createCoworker(planId, authCode);
+        inviteService.createCoworker(planId, authCode);
 
-
-        return ResponseEntity.ok(
-                CommonResponse.<AuthCheckResponseDto>builder()
-                        .response(ResponseEnum.CREATE_COWORKER)
-                        .data(authCheckResponseDto)
-                        .build()
-        );
+        return "redirect:http://localhost:3000/home";
     }
-
-
-
-
-
 
 }

--- a/src/main/java/com/sparta/restplaceforj/service/InviteService.java
+++ b/src/main/java/com/sparta/restplaceforj/service/InviteService.java
@@ -11,15 +11,14 @@ import com.sparta.restplaceforj.repository.CoworkerRepository;
 import com.sparta.restplaceforj.repository.PlanRepository;
 import com.sparta.restplaceforj.repository.UserRepository;
 import com.sparta.restplaceforj.util.AuthCodeUtil;
+import com.sparta.restplaceforj.util.MailUtil;
 import com.sparta.restplaceforj.util.RedisUtil;
 import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 
 @Slf4j
 @Service
@@ -27,16 +26,29 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class InviteService {
 
-    private final JavaMailSender mailSender;
     private final UserRepository userRepository;
     private final PlanRepository planRepository;
     private final CoworkerRepository coworkerRepository;
     private final RedisUtil redisUtil;
     private final AuthCodeUtil authCodeUtil;
+    private final MailUtil mailUtil;
 
-    @Value("${spring.mail.username}")
-    private String configEmail;
+    // 1.1 이메일 송신
+    public void sendEmail(String toEmail, Long planId, User user) throws MessagingException {
+        // 유효성 검사
+        checkEmailInvalidation(toEmail, user, planId);
 
+        // 인증 코드 생성
+        String authCode = authCodeUtil.createAuthCode();
+
+        // 송신
+        mailUtil.sendMail(toEmail, planId, authCode);
+
+        // redis에 송신할 이메일 주소, 인증 코드, 만료 기한(30분) 설정
+        redisUtil.setValuesWithTimeout(authCode, toEmail, AuthCodeUtil.EXPIRATION_TIME);
+    }
+
+    // 1.2 유효성 검사
     public void checkEmailInvalidation(String email, User user, Long planId) {
         //로그인한 유저 스스로 초대할 수 없도록 예외 처리
         if(email.equals(user.getEmail())) {
@@ -46,7 +58,7 @@ public class InviteService {
         // 해당 이메일로 가입한 유저(초대받을 유저)가 있는지 확인
         User willInvitedUser = userRepository.findByEmailOrThrow(email);
 
-        // planId에 해당하는 plan이 있는지 확인
+        // planId에 해당하는 plan이 존재하는지 확인
         Plan plan = planRepository.findByIdOrThrow(planId);
 
         // 초대하려는 유저가 이미 공동작업자로 초대되어 있는지 확인
@@ -55,63 +67,12 @@ public class InviteService {
         }
     }
 
-    private MimeMessage createEmailForm(String toEmail) throws MessagingException {
-
-        // 인증 코드 생성
-        String authCode = authCodeUtil.createAuthCode(toEmail);
-
-        // 메세지 설정
-        MimeMessage message = mailSender.createMimeMessage();
-        message.addRecipients(MimeMessage.RecipientType.TO, toEmail); // 보내는 대상
-        message.setSubject("[J의 안식처] 인증번호"); // 메일 제목
-        message.setFrom(configEmail); //보내는 사람 메일 주소
-
-        String msg="";
-        msg += "<h1 style=\"font-size: 30px; padding-right: 30px; padding-left: 30px;\">이메일 주소 확인</h1>";
-        msg += "<p style=\"font-size: 17px; padding-right: 30px; padding-left: 30px;\">아래 확인 코드를 인증 화면에서 입력해주세요.</p>";
-        msg += "<div style=\"padding-right: 30px; padding-left: 30px; margin: 32px 0 40px;\"><table style=\"border-collapse: collapse; border: 0; background-color: #F4F4F4; height: 70px; table-layout: fixed; word-wrap: break-word; border-radius: 6px;\"><tbody><tr><td style=\"text-align: center; vertical-align: middle; font-size: 30px;\">";
-        msg += authCode;
-        msg += "</td></tr></tbody></table></div>";
-        message.setText(msg, "utf-8", "html");
-
-        // redis에 송신할 이메일 주소, 인증 코드, 만료 기한(30분) 설정
-        redisUtil.setValuesWithTimeout(AuthCodeUtil.SECRET_KEY+toEmail, authCode, AuthCodeUtil.EXPIRATION_TIME);
-
-        return message;
-    }
-
-    // 이메일 송신
-    public void sendEmail(String toEmail) throws MessagingException {
-        // 이미 인증 메일을 보냈다면 인증 코드가 중복될 수 있으므로 제거
-        if (redisUtil.existData(AuthCodeUtil.SECRET_KEY+toEmail)) {
-            redisUtil.deleteValue(AuthCodeUtil.SECRET_KEY+toEmail);
-        }
-
-        // mail.html 템플릿에 따라 이메일 포맷 생성
-        MimeMessage emailForm = createEmailForm(toEmail);
-
-        //송신
-        mailSender.send(emailForm);
-    }
-
-    // 인증코드 검증
-    public String verifyAuthCode(String authCode) {
-        // 유저가 보낸 코드에서 파싱한 이메일과 레디스에 저장된 이메일이 동일한지 확인
-        String email = authCodeUtil.getEmailFromAuthCode(authCode);
-        String authCodeFromRedis = redisUtil.getValues(AuthCodeUtil.SECRET_KEY+email);
-
-        if (!authCode.equals(authCodeFromRedis)) {
-            throw new CommonException(ErrorEnum.INVALID_AUTH_CODE);
-        }
-
-        return email;
-    }
-
-
-    // 초대하려는 유저를 공동작업자로 추가
+    // 2.1 초대한 유저를 공동작업자로 추가
     @Transactional
-    public AuthCheckResponseDto createCoworker(Long planId, String email) {
-        // 초대하려는 유저가 가입되어 있는지 확인
+    public AuthCheckResponseDto createCoworker(Long planId, String authCode) {
+        // authCode 유효성 검사, 유저의 이메일 가져오기
+        String email = authCodeUtil.checkAuthCodeInvalidation(authCode);
+
         User invitedUser = userRepository.findByEmailOrThrow(email);
         Plan plan = planRepository.findByIdOrThrow(planId);
 
@@ -127,4 +88,6 @@ public class InviteService {
                 .coworkerId(coworker.getId())
                 .build();
     }
+
+
 }

--- a/src/main/java/com/sparta/restplaceforj/util/MailUtil.java
+++ b/src/main/java/com/sparta/restplaceforj/util/MailUtil.java
@@ -24,7 +24,7 @@ public class MailUtil {
 
     public MimeMessage createEmailForm(String toEmail, Long planId, String authCode) throws MessagingException {
 
-        String inviteLink = "http://localhost:3000/v1/plans/" + planId + "?authCode=" + authCode;
+        String inviteLink = "http://localhost:8080/v1/plans/" + planId + "/invite?authCode=" + authCode;
 
         // 메세지 설정
         MimeMessage message = mailSender.createMimeMessage();

--- a/src/main/java/com/sparta/restplaceforj/util/MailUtil.java
+++ b/src/main/java/com/sparta/restplaceforj/util/MailUtil.java
@@ -1,0 +1,45 @@
+package com.sparta.restplaceforj.util;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
+
+@Slf4j(topic = "MailUtil")
+@Component
+@RequiredArgsConstructor
+public class MailUtil {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username}")
+    private String configEmail;
+
+    public void sendMail(String toEmail, Long planId, String authCode) throws MessagingException {
+        mailSender.send(createEmailForm(toEmail, planId, authCode));
+    }
+
+    public MimeMessage createEmailForm(String toEmail, Long planId, String authCode) throws MessagingException {
+
+        String inviteLink = "http://localhost:3000/v1/plans/" + planId + "?authCode=" + authCode;
+
+        // 메세지 설정
+        MimeMessage message = mailSender.createMimeMessage();
+        message.addRecipients(MimeMessage.RecipientType.TO, toEmail); // 보내는 대상
+        message.setFrom(configEmail); //보내는 사람 메일 주소
+        message.setSubject("[J의 안식처] 인증번호"); // 메일 제목
+
+        String msg="";
+        msg += "<h1 style=\"font-size: 30px; padding-right: 30px; padding-left: 30px;\">[J의 안식처] 여행 계획 공동 작업자 초대</h1>";
+        msg += "<p style=\"font-size: 17px; padding-right: 30px; padding-left: 30px;\">아래 링크로 접속해서 인증을 완료하세요!</p>";
+        msg += "<div style=\"padding-right: 30px; padding-left: 30px; margin: 32px 0 40px;\"><table style=\"border-collapse: collapse; border: 0; background-color: #F4F4F4; height: 70px; table-layout: fixed; word-wrap: break-word; border-radius: 6px;\"><tbody><tr><td style=\"text-align: center; vertical-align: middle; font-size: 30px;\">";
+        msg += inviteLink;
+        msg += "</td></tr></tbody></table></div>";
+        message.setText(msg, "utf-8", "html");
+
+        return message;
+    }
+}

--- a/src/main/java/com/sparta/restplaceforj/util/MailUtil.java
+++ b/src/main/java/com/sparta/restplaceforj/util/MailUtil.java
@@ -32,13 +32,13 @@ public class MailUtil {
         message.setFrom(configEmail); //보내는 사람 메일 주소
         message.setSubject("[J의 안식처] 인증번호"); // 메일 제목
 
-        String msg="";
-        msg += "<h1 style=\"font-size: 30px; padding-right: 30px; padding-left: 30px;\">[J의 안식처] 여행 계획 공동 작업자 초대</h1>";
-        msg += "<p style=\"font-size: 17px; padding-right: 30px; padding-left: 30px;\">아래 링크로 접속해서 인증을 완료하세요!</p>";
-        msg += "<div style=\"padding-right: 30px; padding-left: 30px; margin: 32px 0 40px;\"><table style=\"border-collapse: collapse; border: 0; background-color: #F4F4F4; height: 70px; table-layout: fixed; word-wrap: break-word; border-radius: 6px;\"><tbody><tr><td style=\"text-align: center; vertical-align: middle; font-size: 30px;\">";
-        msg += inviteLink;
-        msg += "</td></tr></tbody></table></div>";
-        message.setText(msg, "utf-8", "html");
+        StringBuilder msg = new StringBuilder();
+        msg.append("<h1 style=\"font-size: 30px; padding-right: 30px; padding-left: 30px;\">[J의 안식처] 여행 계획 공동 작업자 초대</h1>");
+        msg.append("<p style=\"font-size: 17px; padding-right: 30px; padding-left: 30px;\">아래 링크로 접속해서 인증을 완료하세요!</p>");
+        msg.append("<div style=\"padding-right: 30px; padding-left: 30px; margin: 32px 0 40px;\"><table style=\"border-collapse: collapse; border: 0; background-color: #F4F4F4; height: 70px; table-layout: fixed; word-wrap: break-word; border-radius: 6px;\"><tbody><tr><td style=\"text-align: center; vertical-align: middle; font-size: 30px;\">");
+        msg.append(inviteLink);
+        msg.append("</td></tr></tbody></table></div>");
+        message.setText(msg.toString(), "utf-8", "html");
 
         return message;
     }


### PR DESCRIPTION
## 📌 연관된 이슈

<!-- 수정하려는 현재 동작을 설명하거나 관련 문제에 대한 링크를 제공해주세요 -->
> Issue Number : #99 

## PR 종류

해당 PR은 어떤 부분에 대한 변화인가요?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] 버그 수정 `FIX`(Hotfix)
- [x] 코드 수정 `MODIFY`
- [x] 기능 추가 `FEAT`
- [ ] 파일 이름 변경 `RENAME`
- [ ] 테스트 코드 추가 `TEST`
- [ ] 코드 스타일 변화 (formatting, local variables) `STYLE`
- [ ] 리팩토링 (no functional changes, no api changes) `REFACTOR`
- [ ] 빌드 관련 내용 추가 및 변화 `BUILD`
- [ ] 문서 내용 추가 및 변화`DOCS`
- [ ] 기타 변경 사항 추 `CHORE`
- [ ] Other... (적어주세요 : )

## 💻 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해 주세요 (이미지 첨부 가능)
![image](https://github.com/user-attachments/assets/4510fcac-6789-4ad0-8c60-57ff9b80e61a)
- 기존 Jwt로 생성하여 너무 길었던 인증 코드를 6자리의 난수로 변경하였습니다.
- 프론트에서 인증 코드를 입력할 창을 만들기 어려울 것 같다고 판단하여 url에 접속하여 인증하는 방식으로 인증 방식을 변경하였습니다.
- 프론트에서 인증 컴포넌트를 만든 후 http://{{host}}:3030/v1/plans/{{plan_id}}?authCode={{auth_code}} 로 주소를 설정하고,
api http://{{host}}:8080/v1/plans/{{plan_id}}?authCode={{auth_code}}를 연결하면 인증할 수 있습니다.


## 해당 PR이 다른 영역에 영향을 미치나요?

- [ ] Yes
- [x] No

<!-- "Yes"를 선택한 경우, 어떤 영향을 끼치는지, 발생 위치 Path를 설명해주세요. -->

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
